### PR TITLE
Feat/langgraph duplicate detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This repository is organized around a documented set of reusable automation **pa
 
 > **Contract rollout status:** newly added workflows ship with a full Contract from day one. Earlier workflows are being migrated to the same format — check a given workflow's own README for its current status, and see [open issues](../../issues) if you'd like to help close the gap on an older one.
 
+> **Warning**: At first try not to use paid API of OpenAI or Claude directly. Try it out from OpenRouter or try out local model based API as its sensible.
+
 ---
 
 ## 🧩 What This Actually Is

--- a/implementations/langgraph/duplicate-issue-detector/README.md
+++ b/implementations/langgraph/duplicate-issue-detector/README.md
@@ -1,0 +1,302 @@
+# 🔍 Semantic Duplicate Issue Detector — LangGraph
+
+**Framework:** LangGraph  
+**Pattern:** [`detect → judge → approve → act`](../../../patterns/detect-judge-approve-act.md)  
+**n8n reference implementation:** [`../n8n/duplicate-issue-detector`](../../n8n/duplicate-issue-detector/)  
+**Contract:** [`contract.yaml`](./contract.yaml)
+
+> **Warning**: At first try not to use paid API of OpenAI or Claude directly. Try it out from OpenRouter or try out local model based API as its sensible.
+
+---
+
+## What this is
+
+A LangGraph implementation of the same duplicate-issue-detection logic as the
+[n8n workflow](../../n8n/duplicate-issue-detector/), built to demonstrate that the
+`detect → judge → approve → act` pattern is genuinely framework-agnostic —
+the same shape, the same contract semantics, a different runtime.
+
+**What it does:**  
+When run against a GitHub issue, it embeds the issue text with OpenAI's
+`text-embedding-3-small`, searches a Qdrant vector store for semantically
+similar previously-indexed issues, and — only above a configurable similarity
+threshold — posts a single comment linking to the probable duplicate. It then
+indexes the current issue so future issues can find it.
+
+**What it never does:**  
+Closes, labels, reassigns, or edits any issue. The contract's `approval_points`
+is intentionally empty because the only side effect is a comment, not an
+irreversible action.
+
+---
+
+## Architecture
+
+```
+START
+  │
+  ▼
+detect_node         ← fetches issue title + body from GitHub API (READ ONLY)
+  │
+  ▼
+judge_node          ← embeds text (OpenAI) + searches Qdrant for closest match
+  │
+  ├── score >= threshold ─────────────────────────────────────┐
+  │                                                            │
+  ▼                                                            │
+act_node            ← posts ONE comment on the triggering issue│
+  │                                                            │
+  ▼                                                            │
+index_node          ← upserts this issue's vector into Qdrant ◄┘
+  │
+  ▼
+END
+```
+
+### Pattern slots
+
+| Slot | Node | Notes |
+|---|---|---|
+| **Detect** | `detect_node` | GitHub API read, no side effects |
+| **Judge** | `judge_node` | OpenAI embed + Qdrant search, no external side effects |
+| **Approve** | *(routing function)* | Contract says `approval_points: []` — the router is the decision boundary; no human gate needed for a comment-only action |
+| **Act** | `act_node` + `index_node` | Two bounded side effects declared in the contract |
+
+### How this differs from the n8n implementation
+
+| Dimension | n8n | LangGraph |
+|---|---|---|
+| Trigger | GitHub webhook (live) | CLI invocation / programmatic call |
+| Backfill | Second flow in same file, manual trigger | Separate `backfill.py` script |
+| State | n8n execution context + Qdrant | Python TypedDict + Qdrant |
+| Observability | n8n execution log | stderr log + stdout JSON summary |
+| Retry | n8n's built-in retry UI | Raises on first failure (per contract) |
+
+**What didn't vary:** the four-stage pattern, the declared permissions, the
+`approval_points: []` claim, and the principle that indexing uses issue number
+as the idempotency key.
+
+---
+
+## Prerequisites
+
+- Python **3.11+**
+- A **GitHub fine-grained Personal Access Token** scoped to one repository:
+  - Permission: **Issues** → Read and Write
+  - (Never Contents, Admin, or any repo-wide write permission)
+- An **OpenAI API key** (for `text-embedding-3-small` embeddings — not chat completions)
+- A **Qdrant instance**:
+  - Local: `docker run -p 6333:6333 qdrant/qdrant` (free, no key needed)
+  - Cloud: [Qdrant Cloud free tier](https://cloud.qdrant.io) (1 GB free)
+
+---
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+cd implementations/langgraph/duplicate-issue-detector
+pip install -e ".[dev]"
+```
+
+### 2. Create the Qdrant collection (one-time)
+
+Run this once before any other step. `text-embedding-3-small` produces
+1 536-dimensional vectors; the collection must match that size:
+
+```bash
+curl -X PUT "$QDRANT_URL/collections/$QDRANT_COLLECTION" \
+  -H "Content-Type: application/json" \
+  -H "api-key: $QDRANT_API_KEY" \
+  -d '{"vectors": {"size": 1536, "distance": "Cosine"}}'
+```
+
+For a local unauthenticated instance, omit the `-H "api-key: ..."` header.
+
+### 3. Configure credentials
+
+```bash
+cp .env.example .env
+# Edit .env with your actual values — never commit this file
+```
+
+| Variable | Description |
+|---|---|
+| `GITHUB_TOKEN` | Fine-grained PAT, issues:read + issues:write |
+| `OPENAI_API_KEY` | OpenAI key (embeddings only) |
+| `QDRANT_URL` | e.g. `http://localhost:6333` |
+| `QDRANT_COLLECTION` | Name of your collection, e.g. `github-issues` |
+| `QDRANT_API_KEY` | Qdrant Cloud key — leave blank for local |
+
+### 4. Backfill existing issues (one-time, before live use)
+
+Without this step, the vector store is empty and detection will never fire:
+
+```bash
+python backfill.py --repo your-org/your-repo
+```
+
+The backfill embeds every open issue and upserts it into Qdrant. It takes
+roughly 1–2 seconds per issue (the default 1-second delay avoids OpenAI
+rate limits). A 200-issue repo takes ~3–4 minutes.
+
+```bash
+# Dry-run first to verify API access without writing anything:
+python backfill.py --repo your-org/your-repo --dry-run
+
+# Custom delay if you have a higher OpenAI tier:
+python backfill.py --repo your-org/your-repo --delay 0.3
+```
+
+---
+
+## Usage
+
+### Run on a specific issue
+
+```bash
+python -m duplicate_issue_detector --issue 42 --repo your-org/your-repo
+```
+
+```bash
+# With a custom threshold:
+python -m duplicate_issue_detector --issue 42 --repo your-org/your-repo --threshold 0.90
+```
+
+**Output** (stdout, JSON):
+```json
+{
+  "issue_number": 42,
+  "repo": "your-org/your-repo",
+  "threshold": 0.87,
+  "issue_title": "App crashes on startup",
+  "best_match_score": 0.921,
+  "best_match_issue_number": 7,
+  "best_match_title": "Application fails to start on Windows",
+  "comment_posted": true,
+  "indexed": true,
+  "run_log": [
+    "detect: fetched #42 title='App crashes on startup'",
+    "judge: score=0.9210 match=#7",
+    "act: posted comment on #42 → match=#7",
+    "index: upserted #42 into github-issues"
+  ]
+}
+```
+
+**Logs** (stderr):
+```
+20:15:01 INFO    START  [repo=your-org/your-repo, issue=#42, threshold=0.87]
+20:15:01 INFO    DETECT  fetching issue #42 from your-org/your-repo
+20:15:02 INFO    JUDGE   embedding issue #42
+20:15:03 INFO    JUDGE   best_score=0.9210, match=#7 ('Application fails to start on Windows')
+20:15:03 INFO    ACT     posting duplicate comment on #42 (match=#7, score=0.9210)
+20:15:04 INFO    INDEX   upserting point id=42 into github-issues
+20:15:04 INFO    END    [comment_posted=True, indexed=True, best_score=0.9210]
+```
+
+### Use as a library
+
+```python
+from duplicate_issue_detector import run
+
+final_state = run(
+    issue_number=42,
+    repo_owner="your-org",
+    repo_name="your-repo",
+    threshold=0.87,
+    qdrant_url="http://localhost:6333",
+    qdrant_collection="github-issues",
+    qdrant_api_key="",
+    github_token="ghp_...",
+    openai_api_key="sk-...",
+)
+
+if final_state["comment_posted"]:
+    print(f"Flagged as duplicate of #{final_state['best_match_issue_number']}")
+```
+
+---
+
+## Threshold tuning
+
+The default threshold of `0.87` is a starting point, not a universal truth.
+Before running this unattended:
+
+1. Run on 5–10 issue pairs you **know** are true duplicates — check the scores
+2. Run on 5–10 pairs that share vocabulary but aren't duplicates — check those too
+3. Set the threshold to the midpoint that separates your two groups cleanly
+
+A threshold tuned on someone else's repo won't necessarily fit yours.
+
+---
+
+## Running the tests
+
+```bash
+# Run all tests (fully offline, no API calls):
+pytest tests/ -v
+
+# Run with coverage:
+pytest tests/ -v --tb=short
+```
+
+All tests mock external calls (GitHub, OpenAI, Qdrant). No API keys required.
+
+---
+
+## Contract
+
+Full machine-readable contract: [`contract.yaml`](./contract.yaml)
+
+| Field | Value |
+|---|---|
+| **Inputs** | GitHub issue number; title + body fetched at runtime |
+| **Outputs** | One GitHub comment (if duplicate found) |
+| **Permissions** | `github: issues:read+write`, `openai: embeddings:read`, `qdrant: read+write on one collection` |
+| **Side effects** | One comment (conditional) + one Qdrant upsert (always) |
+| **Approval points** | None — comment-only, not destructive |
+| **Recovery** | Raises loudly on any dependency failure; nothing is silently swallowed |
+| **Replay semantics** | Idempotent on Qdrant (issue number is point ID); comment is NOT idempotent |
+
+---
+
+## Security notes
+
+- Scope the GitHub token to **one repository** and **Issues permission only** —
+  this workflow never needs Contents, Admin, or any org-level scope
+- Your Qdrant collection stores issue titles and bodies as payload — if
+  self-hosting, ensure it's not publicly accessible without authentication
+- Never commit a real `.env` file — it is in `.gitignore`
+- The `0.87` threshold is a starting point; a false positive posts an
+  unhelpful comment, a false negative misses a duplicate — tune it
+
+---
+
+## Relationship to the pattern and the n8n implementation
+
+This implementation is the first evidence for or against the core claim of the
+[`agent-contracts`](../../../) repository: that patterns outlive frameworks.
+
+The `detect → judge → approve → act` shape is identical between this and the
+n8n workflow. What varied:
+
+- The **Detect trigger** (n8n webhook vs. CLI invocation)
+- The **state container** (n8n execution context vs. Python TypedDict)
+- The **observability** (n8n execution log vs. structured stderr + stdout JSON)
+
+What did **not** vary:
+- The four-stage structure
+- The declared permissions
+- The `approval_points: []` claim and its justification
+- The idempotency mechanism (issue number as vector store key)
+- The principle that the Act stage only performs what the Contract lists
+
+See [`docs/workflow-engineering.md`](../../../docs/workflow-engineering.md#why-do-patterns-outlive-frameworks)
+for the hypothesis this implementation is testing.
+
+---
+
+Part of the [`agent-contracts`](../../../) collection.
+Pattern: [`detect-judge-approve-act`](../../../patterns/detect-judge-approve-act.md)

--- a/implementations/langgraph/duplicate-issue-detector/backfill.py
+++ b/implementations/langgraph/duplicate-issue-detector/backfill.py
@@ -1,0 +1,99 @@
+"""
+Backfill: embed every open issue in a repo and upsert into Qdrant.
+Run once before enabling live detection.
+
+Usage:
+    python backfill.py --repo owner/repo
+    python backfill.py --repo owner/repo --dry-run
+    python backfill.py --repo owner/repo --delay 0.3
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from dotenv import load_dotenv
+load_dotenv()
+
+import httpx
+from github import Github
+from openai import OpenAI
+
+logging.basicConfig(stream=sys.stderr, level=logging.INFO,
+                    format="%(asctime)s %(levelname)-7s %(message)s", datefmt="%H:%M:%S")
+log = logging.getLogger(__name__)
+
+_EMBED_MODEL = "text-embedding-3-small"
+_MAX_CHARS = 6000
+
+
+def _env(name: str) -> str:
+    v = os.getenv(name, "").strip()
+    if not v:
+        log.error("Missing env var: %s", name)
+        sys.exit(1)
+    return v
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--repo", required=True, metavar="OWNER/REPO")
+    p.add_argument("--delay", type=float, default=1.0, help="seconds between issues (default 1.0)")
+    p.add_argument("--dry-run", action="store_true", help="fetch and embed, but skip Qdrant writes")
+    args = p.parse_args()
+
+    owner, repo_name = args.repo.split("/", 1)
+    github_token = _env("GITHUB_TOKEN")
+    openai_api_key = _env("OPENAI_API_KEY")
+    qdrant_url = _env("QDRANT_URL")
+    qdrant_collection = _env("QDRANT_COLLECTION")
+    qdrant_api_key = os.getenv("QDRANT_API_KEY", "")
+
+    qdrant_headers = {"Content-Type": "application/json"}
+    if qdrant_api_key:
+        qdrant_headers["api-key"] = qdrant_api_key
+
+    oai = OpenAI(api_key=openai_api_key)
+    repo = Github(github_token).get_repo(f"{owner}/{repo_name}")
+    issues = list(repo.get_issues(state="open"))
+    log.info("Found %d open issues in %s", len(issues), args.repo)
+
+    for i, issue in enumerate(issues, 1):
+        combined = f"{issue.title}\n\n{issue.body or ''}".strip()[:_MAX_CHARS]
+        log.info("[%d/%d] embedding #%d %r", i, len(issues), issue.number, issue.title[:60])
+
+        vector = oai.embeddings.create(model=_EMBED_MODEL, input=combined).data[0].embedding
+
+        if not args.dry_run:
+            r = httpx.put(
+                f"{qdrant_url.rstrip('/')}/collections/{qdrant_collection}/points",
+                json={"points": [{
+                    "id": issue.number,
+                    "vector": vector,
+                    "payload": {
+                        "issueNumber": issue.number,
+                        "title": issue.title,
+                        "url": issue.html_url,
+                    },
+                }]},
+                headers=qdrant_headers,
+                timeout=30.0,
+            )
+            r.raise_for_status()
+            log.info("[%d/%d] upserted #%d", i, len(issues), issue.number)
+        else:
+            log.info("[%d/%d] dry-run, skipping upsert", i, len(issues))
+
+        if i < len(issues):
+            time.sleep(args.delay)
+
+    log.info("Backfill complete: %d issues processed", len(issues))
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/langgraph/duplicate-issue-detector/contract.yaml
+++ b/implementations/langgraph/duplicate-issue-detector/contract.yaml
@@ -1,0 +1,46 @@
+version: 1
+workflow: duplicate-issue-detector
+framework: langgraph
+
+inputs:
+  - GitHub issue number (passed at invocation time)
+  - Issue title + body fetched from GitHub API at runtime
+
+outputs:
+  - One comment on the triggering issue, only if similarity >= threshold
+
+permissions:
+  - github: issues:read+write   # comment only — never close, label, or edit
+  - openai: embeddings:read
+  - qdrant: read+write on one collection
+
+side_effects:
+  - Posts one comment on the triggering issue, if similarity >= threshold
+  - Writes one vector to the Qdrant collection (always, regardless of duplicate result)
+
+approval_points: []   # intentionally empty — this workflow only ever comments,
+                       # never closes or merges, so no approval gate is required
+
+recovery_strategy: >
+  Any failure (GitHub unreachable, OpenAI error, Qdrant error) raises an
+  exception that propagates to the caller. Nothing is silently skipped.
+  The run fails loudly and visibly.
+
+replay_semantics: >
+  Idempotent on Qdrant — re-running on the same issue number overwrites
+  the existing vector (issue number is the Qdrant point ID).
+  The GitHub comment is NOT idempotent — running twice on the same issue
+  will post two comments if a duplicate is found both times.
+
+dependencies:
+  - GitHub API
+  - OpenAI Embeddings API (text-embedding-3-small)
+  - Qdrant instance (local or cloud)
+
+state: >
+  Persisted in a Qdrant collection — one 1536-dimensional vector per
+  previously-seen issue, with issue number, title, and URL as payload.
+
+observability:
+  - Structured INFO/ERROR logs to stderr during execution
+  - JSON summary to stdout on completion (issue number, scores, flags, run_log)

--- a/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/__init__.py
+++ b/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/__init__.py
@@ -1,0 +1,3 @@
+from .graph import run
+
+__all__ = ["run"]

--- a/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/__main__.py
+++ b/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/__main__.py
@@ -1,0 +1,71 @@
+"""Run: python -m duplicate_issue_detector --issue 42 --repo owner/repo"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from .graph import run
+
+logging.basicConfig(stream=sys.stderr, level=logging.INFO,
+                    format="%(asctime)s %(levelname)-7s %(message)s", datefmt="%H:%M:%S")
+
+
+def _env(name: str) -> str:
+    v = os.getenv(name, "").strip()
+    if not v:
+        print(f"ERROR: {name} not set", file=sys.stderr)
+        sys.exit(1)
+    return v
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--issue", "-i", type=int, required=True)
+    p.add_argument("--repo", "-r", required=True, metavar="OWNER/REPO")
+    p.add_argument("--threshold", "-t", type=float, default=0.87)
+    args = p.parse_args()
+
+    parts = args.repo.split("/", 1)
+    if len(parts) != 2:
+        print("ERROR: --repo must be owner/repo", file=sys.stderr)
+        sys.exit(1)
+    owner, repo = parts
+
+    try:
+        result = run(
+            issue_number=args.issue,
+            repo_owner=owner,
+            repo_name=repo,
+            threshold=args.threshold,
+            github_token=_env("GITHUB_TOKEN"),
+            openai_api_key=_env("OPENAI_API_KEY"),
+            qdrant_url=_env("QDRANT_URL"),
+            qdrant_collection=_env("QDRANT_COLLECTION"),
+            qdrant_api_key=os.getenv("QDRANT_API_KEY", ""),
+        )
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    print(json.dumps({
+        "issue_number": result["issue_number"],
+        "repo": args.repo,
+        "threshold": args.threshold,
+        "issue_title": result.get("issue_title"),
+        "best_score": result.get("best_score", 0.0),
+        "match_number": result.get("match_number"),
+        "match_title": result.get("match_title"),
+        "comment_posted": result.get("comment_posted", False),
+        "indexed": result.get("indexed", False),
+        "run_log": result.get("run_log", []),
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/graph.py
+++ b/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/graph.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from langgraph.graph import END, START, StateGraph
+
+from .nodes import act, detect, index, judge
+from .state import State
+
+log = logging.getLogger(__name__)
+
+
+def _route(state: State) -> Literal["act", "index"]:
+    if state["best_score"] >= state["threshold"]:
+        log.info("ROUTE   score=%.4f >= threshold=%.4f → act", state["best_score"], state["threshold"])
+        return "act"
+    log.info("ROUTE   score=%.4f < threshold=%.4f → index", state["best_score"], state["threshold"])
+    return "index"
+
+
+def build_graph():
+    g = StateGraph(State)
+    g.add_node("detect", detect)
+    g.add_node("judge", judge)
+    g.add_node("act", act)
+    g.add_node("index", index)
+
+    g.add_edge(START, "detect")
+    g.add_edge("detect", "judge")
+    g.add_conditional_edges("judge", _route, {"act": "act", "index": "index"})
+    g.add_edge("act", "index")
+    g.add_edge("index", END)
+
+    return g.compile()
+
+
+def run(
+    issue_number: int,
+    repo_owner: str,
+    repo_name: str,
+    *,
+    threshold: float = 0.87,
+    qdrant_url: str,
+    qdrant_collection: str,
+    qdrant_api_key: str = "",
+    github_token: str,
+    openai_api_key: str,
+) -> State:
+    initial: State = {
+        "issue_number": issue_number,
+        "repo_owner": repo_owner,
+        "repo_name": repo_name,
+        "threshold": threshold,
+        "github_token": github_token,
+        "openai_api_key": openai_api_key,
+        "qdrant_url": qdrant_url,
+        "qdrant_collection": qdrant_collection,
+        "qdrant_api_key": qdrant_api_key,
+        "issue_title": None,
+        "issue_body": None,
+        "combined_text": None,
+        "vector": None,
+        "best_score": 0.0,
+        "match_number": None,
+        "match_title": None,
+        "comment_posted": False,
+        "indexed": False,
+        "run_log": [],
+    }
+    log.info("START   repo=%s/%s issue=#%d threshold=%.2f", repo_owner, repo_name, issue_number, threshold)
+    result = build_graph().invoke(initial)
+    log.info("END     comment_posted=%s indexed=%s score=%.4f",
+             result.get("comment_posted"), result.get("indexed"), result.get("best_score", 0.0))
+    return result

--- a/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/nodes.py
+++ b/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/nodes.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from github import Github, GithubException
+from openai import OpenAI
+
+from .state import State
+
+log = logging.getLogger(__name__)
+
+_EMBED_MODEL = "text-embedding-3-small"
+_EMBED_DIMS = 1536
+_MAX_CHARS = 6000
+_SEARCH_LIMIT = 5
+
+
+def detect(state: State) -> dict[str, Any]:
+    """Fetch issue title + body from GitHub. Read-only, no side effects."""
+    log.info("DETECT  #%d from %s/%s", state["issue_number"], state["repo_owner"], state["repo_name"])
+    try:
+        repo = Github(state["github_token"]).get_repo(f"{state['repo_owner']}/{state['repo_name']}")
+        issue = repo.get_issue(number=state["issue_number"])
+    except GithubException as exc:
+        log.error("DETECT  error: %s", exc)
+        raise
+
+    title = issue.title or ""
+    body = issue.body or ""
+    combined = f"{title}\n\n{body}".strip()[:_MAX_CHARS]
+    log.info("DETECT  title=%r body_len=%d", title, len(body))
+    return {
+        "issue_title": title,
+        "issue_body": body,
+        "combined_text": combined,
+        "run_log": state["run_log"] + [f"detect: #{state['issue_number']} {title!r:.50}"],
+    }
+
+
+def judge(state: State) -> dict[str, Any]:
+    """Embed text via OpenAI, search Qdrant, return best match score."""
+    log.info("JUDGE   embedding #%d", state["issue_number"])
+
+    try:
+        resp = OpenAI(api_key=state["openai_api_key"]).embeddings.create(
+            model=_EMBED_MODEL, input=state["combined_text"]
+        )
+    except Exception as exc:
+        log.error("JUDGE   embed error: %s", exc)
+        raise
+
+    vector = resp.data[0].embedding
+    if len(vector) != _EMBED_DIMS:
+        raise ValueError(f"Expected {_EMBED_DIMS}-dim vector, got {len(vector)}")
+    log.info("JUDGE   embedded, dims=%d", len(vector))
+
+    headers = {"Content-Type": "application/json"}
+    if state["qdrant_api_key"]:
+        headers["api-key"] = state["qdrant_api_key"]
+    try:
+        r = httpx.post(
+            f"{state['qdrant_url'].rstrip('/')}/collections/{state['qdrant_collection']}/points/search",
+            json={"vector": vector, "limit": _SEARCH_LIMIT, "with_payload": True},
+            headers=headers,
+            timeout=30.0,
+        )
+        r.raise_for_status()
+    except Exception as exc:
+        log.error("JUDGE   search error: %s", exc)
+        raise
+
+    results = [
+        hit for hit in r.json().get("result", [])
+        if hit.get("payload", {}).get("issueNumber") != state["issue_number"]
+    ]
+
+    best_score = 0.0
+    match_number = None
+    match_title = None
+    if results:
+        best = results[0]
+        best_score = float(best.get("score", 0.0))
+        match_number = best.get("payload", {}).get("issueNumber")
+        match_title = best.get("payload", {}).get("title")
+
+    log.info("JUDGE   score=%.4f match=#%s", best_score, match_number)
+    return {
+        "vector": vector,
+        "best_score": best_score,
+        "match_number": match_number,
+        "match_title": match_title,
+        "run_log": state["run_log"] + [f"judge: score={best_score:.4f} match=#{match_number}"],
+    }
+
+
+def act(state: State) -> dict[str, Any]:
+    """Post one duplicate comment on the triggering issue."""
+    log.info(
+        "ACT     posting comment on #%d → #%s score=%.4f",
+        state["issue_number"], state["match_number"], state["best_score"],
+    )
+    body = (
+        f"🔍 This issue looks similar to #{state['match_number']} — "
+        f"\"{state['match_title']}\" (similarity: {state['best_score']:.3f}).\n\n"
+        "This is an automated suggestion — a maintainer will confirm."
+    )
+    try:
+        repo = Github(state["github_token"]).get_repo(f"{state['repo_owner']}/{state['repo_name']}")
+        repo.get_issue(number=state["issue_number"]).create_comment(body)
+    except GithubException as exc:
+        log.error("ACT     error: %s", exc)
+        raise
+    log.info("ACT     comment posted")
+    return {
+        "comment_posted": True,
+        "run_log": state["run_log"] + [
+            f"act: commented on #{state['issue_number']} → #{state['match_number']}"
+        ],
+    }
+
+
+def index(state: State) -> dict[str, Any]:
+    """Upsert this issue's vector into Qdrant. Always runs regardless of duplicate result."""
+    log.info("INDEX   upserting #%d into %s", state["issue_number"], state["qdrant_collection"])
+    headers = {"Content-Type": "application/json"}
+    if state["qdrant_api_key"]:
+        headers["api-key"] = state["qdrant_api_key"]
+    try:
+        r = httpx.put(
+            f"{state['qdrant_url'].rstrip('/')}/collections/{state['qdrant_collection']}/points",
+            json={"points": [{
+                "id": state["issue_number"],
+                "vector": state["vector"],
+                "payload": {
+                    "issueNumber": state["issue_number"],
+                    "title": state["issue_title"],
+                    "url": (
+                        f"https://github.com/{state['repo_owner']}"
+                        f"/{state['repo_name']}/issues/{state['issue_number']}"
+                    ),
+                },
+            }]},
+            headers=headers,
+            timeout=30.0,
+        )
+        r.raise_for_status()
+    except Exception as exc:
+        log.error("INDEX   error: %s", exc)
+        raise
+    log.info("INDEX   done")
+    return {
+        "indexed": True,
+        "run_log": state["run_log"] + [f"index: upserted #{state['issue_number']}"],
+    }

--- a/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/state.py
+++ b/implementations/langgraph/duplicate-issue-detector/duplicate_issue_detector/state.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from typing import Optional
+from typing_extensions import TypedDict
+
+
+class State(TypedDict):
+    # inputs — set once at invocation, never changed by nodes
+    issue_number: int
+    repo_owner: str
+    repo_name: str
+    threshold: float
+    github_token: str
+    openai_api_key: str
+    qdrant_url: str
+    qdrant_collection: str
+    qdrant_api_key: str
+
+    # populated by detect
+    issue_title: Optional[str]
+    issue_body: Optional[str]
+    combined_text: Optional[str]
+
+    # populated by judge
+    vector: Optional[list[float]]
+    best_score: float
+    match_number: Optional[int]
+    match_title: Optional[str]
+
+    # populated by act / index
+    comment_posted: bool
+    indexed: bool
+
+    # execution trace
+    run_log: list[str]

--- a/implementations/langgraph/duplicate-issue-detector/pyproject.toml
+++ b/implementations/langgraph/duplicate-issue-detector/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "duplicate-issue-detector-langgraph"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "langgraph>=0.2",
+    "openai>=1.30",
+    "PyGithub>=2.3",
+    "httpx>=0.27",
+    "python-dotenv>=1.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+log_cli = true
+log_cli_level = "INFO"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["duplicate_issue_detector*"]

--- a/implementations/n8n/duplicate-issue-detector/README.md
+++ b/implementations/n8n/duplicate-issue-detector/README.md
@@ -2,6 +2,8 @@
 
 Automatically flags likely-duplicate GitHub issues using semantic similarity — not keyword matching — and leaves the final call to a maintainer.
 
+> **Warning**: At first try not to use paid API of OpenAI or Claude directly. Try it out from OpenRouter or try out local model based API as its sensible.
+
 ---
 
 ## 📖 Overview

--- a/implementations/n8n/duplicate-issue-detector/contract.yaml
+++ b/implementations/n8n/duplicate-issue-detector/contract.yaml
@@ -1,0 +1,41 @@
+# contract.yaml
+version: 1
+workflow: duplicate-issue-detector
+
+inputs:
+  - GitHub issue title + body (from webhook trigger)
+
+outputs:
+  - One comment on the triggering issue, only if a duplicate is found
+
+permissions:
+  - github: issues:write   # comment only — never close, label, or edit
+  - openai: embeddings:read
+  - qdrant: read+write on one collection
+
+side_effects:
+  - Posts one comment on the triggering issue, if similarity >= threshold
+  - Writes one vector to the Qdrant collection
+
+approval_points: []   # intentionally empty — this workflow only ever comments,
+                       # never closes or merges, so no approval gate is required
+
+recovery_strategy: >
+  If Qdrant is unreachable, the run fails loudly and visibly in n8n's
+  execution log. It does not silently skip the duplicate check.
+
+replay_semantics: >
+  Idempotent per issue — re-running on the same issue re-embeds and
+  re-checks, but the Qdrant upsert uses the issue number as point ID,
+  so it overwrites rather than duplicates.
+
+dependencies:
+  - GitHub API
+  - OpenAI Embeddings API
+  - Qdrant instance
+
+state: >
+  Persisted in a Qdrant collection — one vector per previously-seen issue.
+
+observability:
+  - GitHub comment itself is the only execution signal (no separate log/digest)

--- a/implementations/n8n/github-debugger-agent/README.md
+++ b/implementations/n8n/github-debugger-agent/README.md
@@ -2,6 +2,8 @@
 
 An automated code quality agent that fetches your code, detects bugs using an LLM, and fixes them — but only when you say so.
 
+> **Warning**: At first try not to use paid API of OpenAI or Claude directly. Try it out from OpenRouter or try out local model based API as its sensible.
+
 ---
 
 ## 📖 Overview

--- a/implementations/n8n/telegram-github-antigravity-pipeline/README.md
+++ b/implementations/n8n/telegram-github-antigravity-pipeline/README.md
@@ -2,6 +2,8 @@
 
 Message a GitHub issue number to a Telegram bot, and a local LLM reads the issue, hands off the actual coding work to Antigravity, sends you the resulting diff for review, and only pushes to a working branch once you explicitly approve it on Telegram.
 
+> **Warning**: At first try not to use paid API of OpenAI or Claude directly. Try it out from OpenRouter or try out local model based API as its sensible.
+
 ---
 
 ## 📖 Overview

--- a/implementations/n8n/telegram-github-antigravity-pipeline/contract.yaml
+++ b/implementations/n8n/telegram-github-antigravity-pipeline/contract.yaml
@@ -1,0 +1,57 @@
+# contract.yaml
+version: 1
+workflow: telegram-github-antigravity-pipeline
+
+inputs:
+  - Telegram message text naming an issue number and repo (e.g. "check issue #5 in myrepo")
+  - GitHub issue title + body, fetched via GitHub API after the message is parsed
+
+outputs:
+  - A git diff summary sent to Telegram for human review
+  - A new branch pushed to GitHub, only if the human approves
+
+permissions:
+  - telegram: read+send messages, restricted to one allowlisted chat ID
+  - github: issues:read, contents:write   # branch push only — never to main
+  - local-llm: inference via localhost llama.cpp/Ollama server (no external network access required)
+  - antigravity-cli: local shell execution against the working repo directory
+
+side_effects:
+  - Sends Telegram messages at each stage (ack, diff summary, approval prompt, push confirmation or discard notice)
+  - Runs the local Antigravity CLI against the repo's local working directory
+  - Pushes exactly one new branch, named after the issue number, if and only if approved — never pushes to main
+
+approval_points:
+  - Before the branch push: a human reviews the actual git diff on Telegram and must reply
+    with explicit approval. Rejection (or no reply) results in no push and a
+    "discarded" notice — the branch is never created on the rejection path.
+
+recovery_strategy: >
+  If the local LLM server is unreachable, the run fails loudly in n8n's execution
+  log rather than silently skipping the reasoning step. If the Antigravity CLI
+  fails or produces no diff, the workflow does not proceed to request approval
+  for an empty or broken change. If the GitHub push itself fails, it fails
+  loudly — there is no silent retry that could push to an unintended branch.
+
+replay_semantics: >
+  NOT safely repeatable for the same issue without manual cleanup. The branch
+  name is derived directly from the issue number (fix-issue-<number>), so a
+  second run on the same issue before the first branch is merged or deleted
+  will fail at the git checkout -b step rather than silently overwriting or
+  duplicating anything. This is a known limitation, not a designed idempotency
+  guarantee — re-running requires the prior branch to be resolved first.
+
+dependencies:
+  - Telegram Bot API
+  - GitHub API
+  - Local llama.cpp/Ollama server (localhost)
+  - Antigravity CLI (local shell access)
+
+state: >
+  Stateless between runs — no persistent store. The chat-ID allowlist is
+  static configuration, not runtime state.
+
+observability:
+  - The Telegram thread itself is the only execution log — ack, diff, and
+    final push/discard notice are the sole visibility into what happened,
+    with no separate dashboard or digest

--- a/implementations/n8n/telegram-structured-solver-pdf/README.md
+++ b/implementations/n8n/telegram-structured-solver-pdf/README.md
@@ -2,6 +2,8 @@
 
 Message a GitHub issue number to a Telegram bot, and a local LLM reads the issue, hands off the actual coding work to Antigravity, sends you the resulting diff for review, and only pushes to a working branch once you explicitly approve it on Telegram.
 
+> **Warning**: At first try not to use paid API of OpenAI or Claude directly. Try it out from OpenRouter or try out local model based API as its sensible.
+
 ---
 
 ## 📖 Overview

--- a/patterns/detect-judge-approve-act.md
+++ b/patterns/detect-judge-approve-act.md
@@ -1,6 +1,6 @@
 # Pattern: Detect → Judge → Approve → Act
 
-**Status:** Proven — one full implementation exists
+**Status:** Proven — two full implementations exist (n8n + LangGraph)
 **Category:** Reasoning / Safety pattern
 
 ---
@@ -41,8 +41,9 @@ Every workflow in this repository that isn't a pure notification bot follows thi
 | Framework | Implementation | Contract |
 |---|---|---|
 | n8n | [`duplicate-issue-detector`](../implementations/n8n/duplicate-issue-detector) | [contract.yaml](../implementations/n8n/duplicate-issue-detector/contract.yaml) |
+| LangGraph | [`duplicate-issue-detector`](../implementations/langgraph/duplicate-issue-detector) | [contract.yaml](../implementations/langgraph/duplicate-issue-detector/contract.yaml) |
 
-**Not yet built, hypothesis under test:** a LangGraph implementation of this same pattern. See [`docs/workflow-engineering.md`](../docs/workflow-engineering.md#why-do-patterns-outlive-frameworks) for why this specific gap matters more than it might look like it does.
+**The second-framework implementation now exists.** The LangGraph implementation was built from the same pattern and contract shape as the n8n version — same four stages, same declared permissions, same `approval_points: []` claim, same idempotency mechanism. See [`docs/workflow-engineering.md`](../docs/workflow-engineering.md#why-do-patterns-outlive-frameworks) for the hypothesis this implements.
 
 **Other workflows in this repository may also instantiate this pattern** — several look like plausible fits on inspection — but per this project's own governance process, a pattern classification isn't asserted here without a worked-through Contract confirming it. If you believe a workflow belongs in this table, open the discussion under [`rfcs/`](../rfcs) with the Contract that supports it, rather than a one-line addition to this table.
 


### PR DESCRIPTION
Adds the LangGraph implementation of the `duplicate-issue-detector` pattern, proving that patterns outlive frameworks.

Also includes standard AI cost warnings across all LLM-dependent workflows in the repository.

Closes #19
