### PR TITLE
feat: add installable Python package and validation CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,11 @@ npm-debug.log*
 # Local scratch/test files
 *.local.json
 test-output/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+
+# Python packaging/build artifacts
+build/
+dist/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[project]
+name = "agent-contracts"
+version = "0.1.0"
+description = "Framework-independent contracts and validation tooling for AI agents and automated workflows."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+
+authors = [
+    { name = "Shinjan Das" }
+]
+
+dependencies = [
+    "PyYAML>=6.0,<7.0",
+    "jsonschema>=4.20,<5.0",
+]
+
+[project.scripts]
+agent-contracts = "agent_contracts.cli:main"
+
+[project.urls]
+Repository = "https://github.com/Skull-boy/agent-contracts"
+Issues = "https://github.com/Skull-boy/agent-contracts/issues"
+
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+
+[tool.setuptools.package-data]
+agent_contracts = [
+    "schemas/v1/*.json"
+]

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -25,10 +25,7 @@ def main():
         relative_path = contract_path.relative_to(ROOT)
 
         try:
-            result = validate_contract(
-                contract_path=contract_path,
-                schema_path=SCHEMA_PATH,
-            )
+            result = validate_contract(contract_path)
 
             if result.valid:
                 print(f"PASS  {relative_path}")

--- a/src/agent_contracts/cli.py
+++ b/src/agent_contracts/cli.py
@@ -1,0 +1,81 @@
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+from .validator import validate_contract
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agent-contracts",
+        description="Validate Agent Contract files.",
+    )
+
+    subparsers = parser.add_subparsers(
+        dest="command",
+        required=True,
+    )
+
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Validate an Agent Contract.",
+    )
+
+    validate_parser.add_argument(
+        "contract",
+        type=Path,
+        help="Path to contract.yaml",
+    )
+
+    return parser
+
+
+def run_validate(contract_path: Path) -> int:
+    try:
+        result = validate_contract(contract_path)
+
+    except FileNotFoundError:
+        print(f"ERROR  {contract_path}")
+        print("       file not found")
+        return 2
+
+    except PermissionError:
+        print(f"ERROR  {contract_path}")
+        print("       permission denied")
+        return 2
+
+    except yaml.YAMLError as error:
+        print(f"FAIL  {contract_path}")
+        print(f"      invalid YAML: {error}")
+        return 1
+
+    if result.valid:
+        print(f"PASS  {contract_path}")
+        return 0
+
+    print(f"FAIL  {contract_path}")
+
+    for error in result.errors:
+        if error.path:
+            print(f"      {error.path}: {error.message}")
+        else:
+            print(f"      {error.message}")
+
+    return 1
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "validate":
+        return run_validate(args.contract)
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agent_contracts/schemas/v1/contract.schema.json
+++ b/src/agent_contracts/schemas/v1/contract.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agent Contract v1",
+  "description": "Machine-readable schema for an Agent Contract.",
+  "type": "object",
+
+  "required": [
+    "version",
+    "workflow",
+    "inputs",
+    "outputs",
+    "permissions",
+    "side_effects",
+    "approval_points",
+    "recovery_strategy",
+    "replay_semantics",
+    "dependencies",
+    "state",
+    "observability"
+  ],
+
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+
+    "workflow": {
+      "type": "string"
+    },
+
+    "framework": {
+      "type": "string"
+    },
+
+    "inputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+
+    "outputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "minProperties": 1,
+        "maxProperties": 1,
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    },
+
+    "side_effects": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+
+    "approval_points": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+
+    "recovery_strategy": {
+      "type": "string"
+    },
+
+    "replay_semantics": {
+      "type": "string"
+    },
+
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+
+    "state": {
+      "type": "string"
+    },
+
+    "observability": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/agent_contracts/validator.py
+++ b/src/agent_contracts/validator.py
@@ -7,6 +7,10 @@ import yaml
 from jsonschema import Draft202012Validator
 
 
+PACKAGE_ROOT = Path(__file__).resolve().parent
+DEFAULT_SCHEMA_PATH = PACKAGE_ROOT / "schemas" / "v1" / "contract.schema.json"
+
+
 @dataclass(frozen=True)
 class ValidationError:
     path: str
@@ -27,7 +31,7 @@ def load_contract(path: str | Path) -> Any:
         return yaml.safe_load(file)
 
 
-def load_schema(path: str | Path) -> dict[str, Any]:
+def load_schema(path: str | Path = DEFAULT_SCHEMA_PATH) -> dict[str, Any]:
     """Load an Agent Contract JSON Schema."""
     schema_path = Path(path)
 
@@ -37,16 +41,25 @@ def load_schema(path: str | Path) -> dict[str, Any]:
 
 def validate_contract(
     contract_path: str | Path,
-    schema_path: str | Path,
+    schema_path: str | Path | None = None,
 ) -> ValidationResult:
     """
-    Validate one Agent Contract against an Agent Contract JSON Schema.
+    Validate one Agent Contract.
+
+    By default, the Contract is validated against the Agent Contract v1
+    schema bundled with this package.
+
+    A custom schema path may be supplied explicitly for development,
+    testing, or experimental schema versions.
 
     This function performs no printing and does not terminate the process.
     Callers decide how validation results should be presented.
     """
     contract = load_contract(contract_path)
-    schema = load_schema(schema_path)
+
+    schema = load_schema(
+        DEFAULT_SCHEMA_PATH if schema_path is None else schema_path
+    )
 
     if contract is None:
         return ValidationResult(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from agent_contracts.cli import main
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_cli_valid_contract_returns_zero(monkeypatch, capsys):
+    contract = (
+        ROOT
+        / "implementations"
+        / "n8n"
+        / "duplicate-issue-detector"
+        / "contract.yaml"
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["agent-contracts", "validate", str(contract)],
+    )
+
+    exit_code = main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "PASS" in output
+
+
+def test_cli_invalid_contract_returns_one(monkeypatch, capsys):
+    contract = ROOT / "tests" / "fixtures" / "invalid-version.yaml"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["agent-contracts", "validate", str(contract)],
+    )
+
+    exit_code = main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "FAIL" in output
+    assert "version" in output
+
+
+def test_cli_missing_file_returns_two(monkeypatch, capsys):
+    contract = ROOT / "tests" / "fixtures" / "does-not-exist.yaml"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["agent-contracts", "validate", str(contract)],
+    )
+
+    exit_code = main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 2
+    assert "ERROR" in output
+    assert "file not found" in output

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -19,7 +19,7 @@ def test_valid_contract_passes():
         / "contract.yaml"
     )
 
-    result = validate_contract(contract, SCHEMA)
+    result = validate_contract(contract)
 
     assert result.valid is True
     assert result.errors == ()
@@ -50,4 +50,4 @@ def test_malformed_yaml_raises_yaml_error():
     contract = ROOT / "tests" / "fixtures" / "malformed.yaml"
 
     with pytest.raises(yaml.YAMLError):
-        validate_contract(contract, SCHEMA)
+        validate_contract(contract)


### PR DESCRIPTION
## Summary

Introduces the first installable Python package and CLI for Agent Contracts.

This moves contract validation from a repository-only script toward reusable tooling that can be installed and used independently of the implementation framework.

## What changed

- Added `agent_contracts` as an installable Python package using the `src/` layout
- Added `pyproject.toml` with package metadata and runtime dependencies
- Bundled the Contract v1 JSON Schema inside the package
- Added a reusable `validate_contract()` Python API
- Added the `agent-contracts` CLI
- Added `agent-contracts validate <contract.yaml>`
- Added explicit CLI exit codes:
  - `0` — valid contract
  - `1` — invalid contract / malformed YAML
  - `2` — CLI or filesystem error
- Refactored repository-wide validation to use the reusable validator
- Added validator and CLI test coverage
- Updated `.gitignore` for Python build/cache artifacts

## Usage

Python:

```python
from agent_contracts import validate_contract

result = validate_contract("contract.yaml")
print(result.valid)